### PR TITLE
docs: fix simple typo, memebers -> members

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Rebirth rate controls how much energy is stored within an agent before splitting
 ### Dietary preference 
 Agent's dietary preference influences what food source an agent will pursue and consume: living or non-living. For an ecosystem to be stable, the need for agents of both these groups is required.
 ### Flocking strength
-Flocking is a behaviour in which agents form groups, or clusters, whilst navigating the map, forming "multicellular life". Paradoxically this offers both safety and vulnerability. By sharing information whilst flocking, a group increases it's memebers knowledge of other potential dangers or food. In contrast, if the group fails to avoid a potential danger the whole group suffers.
+Flocking is a behaviour in which agents form groups, or clusters, whilst navigating the map, forming "multicellular life". Paradoxically this offers both safety and vulnerability. By sharing information whilst flocking, a group increases it's members knowledge of other potential dangers or food. In contrast, if the group fails to avoid a potential danger the whole group suffers.
 ### Wobble frequency
 Whilst moving around the screen, agents speed up and down in a sinusoidal pattern, creating a "crawling" effect. The frequency of this movement is dictated by the wobble trait. Wobbling has both advantages and disadvantages, with a lower frequency resulting in longer periods of increased speed but also longer resting periods.
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `members` rather than `memebers`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md